### PR TITLE
OAuth2 회원가입 로직 & 기타 이슈 개선

### DIFF
--- a/oauthJwt/src/main/java/com/example/socialCrawler/SocialCrawlerApplication.java
+++ b/oauthJwt/src/main/java/com/example/socialCrawler/SocialCrawlerApplication.java
@@ -3,7 +3,7 @@ package com.example.socialCrawler;
 import com.example.socialCrawler.config.AppProperties;
 import com.example.socialCrawler.domain.entity.User;
 import com.example.socialCrawler.domain.entity.UserRole;
-import com.example.socialCrawler.domain.repository.UserRepository;
+import com.example.socialCrawler.repository.UserRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;

--- a/oauthJwt/src/main/java/com/example/socialCrawler/controller/AuthController.java
+++ b/oauthJwt/src/main/java/com/example/socialCrawler/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.example.socialCrawler.security.jwt.TokenProvider;
 import com.example.socialCrawler.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -32,6 +33,11 @@ public class AuthController {
     private final TokenProvider tokenProvider;
 
     private final CustomUserDetailsService userDetailsService;
+
+    @GetMapping("/welcome")
+    public String welcome() {
+        return "Welcome!";
+    }
 
     @PostMapping("/login")
     public ResponseEntity<?> authenticateUser(@Valid @RequestBody AuthRequest authRequest) {
@@ -59,7 +65,8 @@ public class AuthController {
     }
 
     @GetMapping("/token")
-    public ResponseEntity<?> validateToken(@RequestParam String token) {
+    public ResponseEntity<?> validateToken(@RequestParam @Nullable String token) {
+
         boolean validateToken = tokenProvider.validateToken(token);
         if (validateToken) {
             return ResponseEntity.ok(new AuthResponse(token));

--- a/oauthJwt/src/main/java/com/example/socialCrawler/repository/JpaOAuthInfoRepository.java
+++ b/oauthJwt/src/main/java/com/example/socialCrawler/repository/JpaOAuthInfoRepository.java
@@ -1,4 +1,4 @@
-package com.example.socialCrawler.domain.repository;
+package com.example.socialCrawler.repository;
 
 import com.example.socialCrawler.domain.entity.AuthProvider;
 import com.example.socialCrawler.domain.entity.OAuthInfo;

--- a/oauthJwt/src/main/java/com/example/socialCrawler/repository/UserRepository.java
+++ b/oauthJwt/src/main/java/com/example/socialCrawler/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package com.example.socialCrawler.domain.repository;
+package com.example.socialCrawler.repository;
 
 import com.example.socialCrawler.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/oauthJwt/src/main/java/com/example/socialCrawler/security/oauth2/CustomOauth2UserService.java
+++ b/oauthJwt/src/main/java/com/example/socialCrawler/security/oauth2/CustomOauth2UserService.java
@@ -3,8 +3,9 @@ package com.example.socialCrawler.security.oauth2;
 import com.example.socialCrawler.domain.entity.AuthProvider;
 import com.example.socialCrawler.domain.entity.OAuthInfo;
 import com.example.socialCrawler.domain.entity.User;
-import com.example.socialCrawler.domain.repository.JpaOAuthInfoRepository;
-import com.example.socialCrawler.domain.repository.UserRepository;
+import com.example.socialCrawler.exception.UserAlreadyExistsException;
+import com.example.socialCrawler.repository.JpaOAuthInfoRepository;
+import com.example.socialCrawler.repository.UserRepository;
 import com.example.socialCrawler.exception.OAuth2AuthenticationProcessingException;
 import com.example.socialCrawler.security.UserPrincipal;
 import com.example.socialCrawler.security.oauth2.user.OAuth2UserInfo;
@@ -15,6 +16,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.Optional;
@@ -30,6 +32,7 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         this.oAuthInfoRepository = oAuthInfoRepository;
     }
 
+    @Transactional
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
@@ -37,7 +40,9 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         try {
             return processOAuth2User(userRequest, oAuth2User);
         } catch (OAuth2AuthenticationProcessingException ex) {
-            // TODO: 왜 AuthenticationException으로는 catch가 안되는것일까
+            // TODO: 왜 AuthenticationException 으로는 catch 가 안되는것일까
+            throw ex;
+        } catch (UserAlreadyExistsException ex) {
             throw ex;
         } catch (Exception ex) {
             // AuthenticationException 인스턴스가 OAuth2AuthenticationFailureHandler 를 작동시킨다
@@ -45,26 +50,35 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
         }
     }
 
-    private OAuth2User processOAuth2User(OAuth2UserRequest request, OAuth2User oAuth2User) {
+    private OAuth2User processOAuth2User(OAuth2UserRequest request, OAuth2User oAuth2User) throws OAuth2AuthenticationProcessingException {
         AuthProvider authProvider = AuthProvider.valueOf(request.getClientRegistration().getRegistrationId());
         OAuth2UserInfo oAuth2UserInfo = Oauth2UserInfoFactory.getOAuth2UserInfo(request.getClientRegistration().getRegistrationId(), oAuth2User.getAttributes());
         if (!StringUtils.hasText(oAuth2UserInfo.getEmail())) {
             throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 provider");
         }
 
-        // OAuthInfo에서 조회하여 비교
+        // OAuthInfo 에서 조회하여 비교
         Optional<OAuthInfo> oAuthInfoOptional = oAuthInfoRepository.findByEmailAndAuthProvider(oAuth2UserInfo.getEmail(), authProvider);
+        Optional<User> userByEmail = userRepository.findByEmail(oAuth2UserInfo.getEmail());
         OAuthInfo oAuthInfo;
         User user;
 
         if (oAuthInfoOptional.isPresent()) {
+            // email/provider 를 가진 기존 OAuth2 정보 존재시
+            // 기존 유저 정보 DTO 반환
             oAuthInfo = oAuthInfoOptional.get();
 
             if (!oAuthInfo.getAuthProvider().equals(AuthProvider.valueOf(request.getClientRegistration().getRegistrationId()))) {
                 throw new OAuth2AuthenticationProcessingException(authProvider + " OAuth Login is not supported.");
             }
             user = oAuthInfo.getUser();
+        } else if (userByEmail.isPresent()) {
+            // OAuth2 정보 없이 email 을 가진 유저가 있을 경우
+            // 유저에러: OAuth2AuthenticationFailureHandler.onAuthenticationFailure 에서 처리
+            throw new OAuth2AuthenticationProcessingException(oAuth2UserInfo.getEmail() + " Email user already exists");
         } else {
+            // 모든 정보가 없을 경우
+            // 새로운 유저 정보 생성
             user = registerNewUser(request, oAuth2UserInfo);
         }
 

--- a/oauthJwt/src/main/java/com/example/socialCrawler/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/oauthJwt/src/main/java/com/example/socialCrawler/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,9 +1,19 @@
 package com.example.socialCrawler.security.oauth2;
 
+import com.example.socialCrawler.exception.UserAlreadyExistsException;
 import com.example.socialCrawler.utils.CookieUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.WebAttributes;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.session.SessionAuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -12,21 +22,43 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.example.socialCrawler.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 @Component
-public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+    // TODO: SimpleUrlAuthenticationFailureHandler 에서 AuthenticationFailureHandler 로 변경
 
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
+    private final MappingJackson2HttpMessageConverter httpMessageConverter;
+
+    private static final MediaType CONTENT_TYPE_JSON = MediaType.APPLICATION_JSON;
+
     @Autowired
-    public OAuth2AuthenticationFailureHandler(HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository) {
+    public OAuth2AuthenticationFailureHandler(HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository, MappingJackson2HttpMessageConverter httpMessageConverter) {
         this.httpCookieOAuth2AuthorizationRequestRepository = httpCookieOAuth2AuthorizationRequestRepository;
+        this.httpMessageConverter = httpMessageConverter;
     }
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+
+        // TODO: Exception 종류에 따른 HTTP status code 와 에러 메시지 분류
+        Map<String, Object> data = new HashMap<>();
+        data.put(
+                "errorMessage",
+                exception.getMessage());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        HttpOutputMessage message = new ServletServerHttpResponse(response);
+        httpMessageConverter.write(data, CONTENT_TYPE_JSON, message);
+    }
+
+    @Deprecated
+    public void redirectToFailureUrl(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
                 .map(Cookie::getValue)
                 .orElse(("/"));
@@ -37,6 +69,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
 
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+        // SimpleUrlAuthenticationFailureHandler 상속 기준에서 redirect 처리 시
+//        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/oauthJwt/src/main/java/com/example/socialCrawler/service/CustomUserDetailsService.java
+++ b/oauthJwt/src/main/java/com/example/socialCrawler/service/CustomUserDetailsService.java
@@ -2,11 +2,10 @@ package com.example.socialCrawler.service;
 
 import com.example.socialCrawler.domain.dto.UserSignUpRequest;
 import com.example.socialCrawler.domain.entity.User;
-import com.example.socialCrawler.domain.repository.UserRepository;
+import com.example.socialCrawler.repository.UserRepository;
 import com.example.socialCrawler.exception.ResourceNotFoundException;
 import com.example.socialCrawler.exception.UserAlreadyExistsException;
 import com.example.socialCrawler.security.UserPrincipal;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -21,7 +20,6 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
-    @Autowired
     public CustomUserDetailsService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }


### PR DESCRIPTION
https://github.com/roamgom/Spring_TIL/issues/2#issuecomment-1193786214

OAuth2 로그인 시
OAuth2Info entity 조회 -> OAuth2Info & User entity 조회 후
새로운 회원가입 요청의 email/provider에 맞는 OAuth2Info 내역 혹은 email에 맞는 User 내역 존재 시
ErrorHandler 적용

https://github.com/roamgom/Spring_TIL/blob/8d020c883c1f2b97262038f3fb971b02308e87a8/oauthJwt/src/main/java/com/example/socialCrawler/security/oauth2/OAuth2AuthenticationFailureHandler.java#L46-L58

---

https://github.com/roamgom/Spring_TIL/issues/2#issuecomment-1193786317

CustomUserDetailsService 와 SecurityConfig 간 password Bean으로 인해 circular reference 문제
<img width="1524" alt="image" src="https://user-images.githubusercontent.com/24652225/180757268-b2dd1590-03e4-4f9b-b04a-78e3d3bbae6a.png">

-> 해결책 2가지
1. 인증을 위한 CustomUserDetailsService 와 별도의 UserService 생성 후 passwordEncoder Bean 주입 후, 회원가입 기능 추가
2. CustomUserDetailsService 회원가입 기능에서 별도의 passwordEncoder 인스턴스 생성

-> 서비스 규모가 커지면 1번 선택지가 적합. 현재 boilerplate 기준에서는 2번이 적합

https://github.com/roamgom/Spring_TIL/blob/8d020c883c1f2b97262038f3fb971b02308e87a8/oauthJwt/src/main/java/com/example/socialCrawler/service/CustomUserDetailsService.java#L49-L57